### PR TITLE
fix windtools causing errors in ActionBar Masks

### DIFF
--- a/ElvUI_ActionBarMasks/Core.lua
+++ b/ElvUI_ActionBarMasks/Core.lua
@@ -106,6 +106,12 @@ function ABM:UpdateOptions()
 	local path = ABM:GetValidBorder()
 	local db = E.db.abm.global
 	local cooldown
+	
+	--windtools by default reskins elvui actionbars, disable that setting to prevent errors
+	if IsAddOnLoaded("ElvUI_WindTools")  then
+		E.private["WT"]["skins"]["elvui"]["actionBarsBackdrop"] = false
+		E.private["WT"]["skins"]["elvui"]["actionBarsButton"] = false
+	end
 
 	for button in pairs(AB.handledbuttons) do
 		if button then


### PR DESCRIPTION
Windtools skins ElvUI actionbars, this causes ActionBar Masks to error out because the function from Elvui is modified.

To prevent this simply disable the setting from Windtools if its enabled since its incompatible.